### PR TITLE
Add timeout to the debug_traceBlockByNumber RPC

### DIFF
--- a/ethereumetl/json_rpc_requests.py
+++ b/ethereumetl/json_rpc_requests.py
@@ -30,11 +30,12 @@ def generate_get_block_by_number_json_rpc(block_numbers, include_transactions):
         )
 
 
-def generate_trace_block_by_number_json_rpc(block_numbers):
+def generate_trace_block_by_number_json_rpc(block_numbers, timeout='600s'):
     for block_number in block_numbers:
         yield generate_json_rpc(
             method='debug_traceBlockByNumber',
-            params=[hex(block_number), {'tracer': 'callTracer'}],
+            # add timeout to request params to resolve the execution timeout error
+            params=[hex(block_number), {'tracer': 'callTracer', 'timeout': timeout}],
             # save block_number in request ID, so later we can identify block number in response
             request_id=block_number,
         )


### PR DESCRIPTION
The Ethereum RPC follows [JSON RPC 2.0](https://www.jsonrpc.org/specification), so the timeout must be passed in POST body. The [BatchHTTPProvider](https://github.com/datawaves-xyz/ethereum-etl/blob/develop/ethereumetl/providers/rpc.py) does not encode timeout to params:
```
 Request: [{"jsonrpc": "2.0", "method": "debug_traceBlockByNumber", "params": ["0x1cfe0f9", {"tracer": "callTracer"}], "id": 30400761}]
```